### PR TITLE
Add runnable tests using Node's test module

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "version": "6.3.10",
   "scripts": {
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
-    "format": "prettier --write \"src/**/*.ts\""
+    "format": "prettier --write \"src/**/*.ts\"",
+    "test": "NODE_PATH=tests/stubs node --test tests/*.test.js"
   },
   "devDependencies": {
     "@types/chai": "^4.3.5",

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('assert');
+const path = require('path');
+const { GridFSPromise } = require('../src/GridFSPromise.js');
+
+test('connection getter and setter work', () => {
+  const grid = new GridFSPromise('db');
+  assert.strictEqual(grid.connection, null);
+  const fake = {};
+  grid.CONNECTION = fake;
+  assert.strictEqual(grid.connection, fake);
+});
+
+test('closeConnection resolves when no connection is set', async () => {
+  const grid = new GridFSPromise('db');
+  const result = await grid.closeConnection();
+  assert.strictEqual(result, true);
+});
+
+test('closeConnection calls close on provided connection', async () => {
+  let closed = false;
+  const fakeClient = {
+    close() {
+      closed = true;
+      return Promise.resolve();
+    },
+  };
+  const grid = new GridFSPromise('db');
+  grid.CONNECTION = fakeClient;
+  const result = await grid.closeConnection();
+  assert.strictEqual(result, true);
+  assert.ok(closed);
+});
+
+test('getFileStream rejects when no connection string is provided', async () => {
+  const grid = new GridFSPromise('db');
+  await assert.rejects(() => grid.getFileStream('000000000000000000000000'), /No Connection String given/);
+});

--- a/tests/stubs/bson/index.js
+++ b/tests/stubs/bson/index.js
@@ -1,0 +1,6 @@
+class ObjectID {
+  constructor(id) {
+    this.id = id;
+  }
+}
+module.exports = { ObjectID };

--- a/tests/stubs/mongodb/index.js
+++ b/tests/stubs/mongodb/index.js
@@ -1,0 +1,11 @@
+class MongoClient {
+  static connect() {
+    return Promise.reject(new Error('MongoClient stub'));
+  }
+  db() {
+    return {};
+  }
+}
+class GridFSBucket {}
+class GridFSBucketReadStream {}
+module.exports = { MongoClient, GridFSBucket, GridFSBucketReadStream };


### PR DESCRIPTION
## Summary
- add a `test` npm script using Node's built-in test runner
- create basic tests that check connection handling
- provide stub modules for `mongodb` and `bson` so tests run without dependencies

## Testing
- `npm test`